### PR TITLE
Added A Standardized Search Docus

### DIFF
--- a/docs/search_result_guidelines.md
+++ b/docs/search_result_guidelines.md
@@ -68,7 +68,7 @@ To search, the client makes a Http GET Request to the enpoint as detail above.
 ```
 ### Attributes Description.
 
-The table gives cotext to some of the response attributes.
+The table gives context to some of the response attributes/fields.
 
 | S/N | Attribute                             | Description                                                                               
 | :-- | :------------------------------------ | :----------------------------------------------------------------------- | 


### PR DESCRIPTION
Created and added documentation detailing the standardized guidelines for search-related responses.
The guideline is a documentation for how Zuri-main client-side is to interacts with plugin's search APIs and vice-visa.

Changes made:
- Added a File called search_result_guidline.
