### PR TITLE
Adjusted The H1 to reflect accordingly

### DIFF
--- a/docs/search_result_guidelines.md
+++ b/docs/search_result_guidelines.md
@@ -1,4 +1,4 @@
-## Guidelines On How To Serve Search Results
+# Guidelines On How To Serve Search Results
 
 
 All searches on Zuri chat are plugin base. Depending on the current active plugin, a user search is filtered base on the resources available on the plugin.


### PR DESCRIPTION
The initial Commit had no H1 heading, so the file name is being mistaken for the Main header by the doc program.
Changes made:

- The header in the documentation file is now formatted to H1

This should correct the display distortion as seen [HERE](https://docs.zuri.chat/search_result_guidelines)